### PR TITLE
Skip call to this.setupVideo(); in ngAfterViewInit on multi cam view …

### DIFF
--- a/client/src/app/live-container/live-container.component.ts
+++ b/client/src/app/live-container/live-container.component.ts
@@ -67,7 +67,8 @@ export class LiveContainerComponent implements OnInit, AfterViewInit, OnDestroy 
 
   ngAfterViewInit(): void {
     this.activeLiveUpdates = this.cameraSvc.getActiveLiveUpdates().subscribe(() => this.setupVideo());
-    this.setupVideo();
+    if(!this.multi)
+      this.setupVideo();
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
…to prevent the No camera selected box coming up briefly.