### PR TITLE
Fix problem with onvif dependencies which caused w3.org to be called on port 80. 

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -126,14 +126,26 @@ dependencies {
     testRuntimeOnly "org.seleniumhq.selenium:selenium-firefox-driver:3.14.0"
 
     // Onvif dependencies
-    implementation group: 'org.apache.cxf', name: 'cxf-rt-bindings-soap', version: '3.4.4'
-    implementation 'org.apache.cxf:cxf-rt-frontend-jaxws:3.4.3'
-    implementation group: 'org.apache.cxf', name: 'cxf-rt-transports-http', version: '3.4.4'
-    implementation group: 'org.apache.cxf', name: 'cxf-core', version: '3.4.4'
-    implementation group: 'javax.jws', name: 'jsr181-api', version: '1.0-MR1'
-    implementation 'commons-codec:commons-codec:1.15'
-    implementation group: 'org.apache.wss4j', name: 'wss4j-ws-security-common', version: '2.4.1'
+
+    implementation group: 'org.apache.cxf', name: 'cxf-rt-frontend-jaxws', version: '3.3.2'
+    implementation group: 'org.apache.cxf', name: 'cxf-rt-transports-http-jetty', version: '3.3.2'
     implementation group: 'javax.xml.ws', name: 'jaxws-api', version: '2.3.1'
+    implementation group: 'javax.jws', name: 'javax.jws-api', version: '1.1'
+    implementation group: 'org.apache.cxf.services.wsn', name: 'cxf-services-wsn-core', version: '3.3.2'
+    compileOnly group: 'org.apache.commons', name: 'commons-lang3', version: '3.8.1'
+    implementation group: 'commons-codec', name: 'commons-codec', version: '1.10'
+    implementation group: 'org.apache.wss4j', name: 'wss4j-ws-security-common', version: '2.2.3'
+    implementation group: 'org.apache.cxf.xjc-utils', name: 'cxf-xjc-runtime', version: '3.3.0'
+    implementation group: 'org.apache.cxf', name: 'cxf-rt-bindings-soap', version: '3.1.0'
+    implementation group: 'org.apache.cxf.xjcplugins', name: 'cxf-xjc-boolean', version: '3.1.0'
+    implementation group: 'org.apache.cxf.xjcplugins', name: 'cxf-xjc-ts', version: '3.1.0'
+    implementation group: 'org.apache.cxf.xjc-utils', name: 'cxf-xjc-runtime', version: '3.3.0'
+    implementation group: 'org.apache.maven', name: 'maven-model-builder', version: '3.6.1'
+    implementation group: 'com.sun.activation', name: 'javax.activation', version: '1.2.0'
+    implementation group: 'javax.xml.bind', name: 'jaxb-api', version: '2.3.1'
+    implementation group: 'com.sun.xml.bind', name: 'jaxb-impl', version: '2.3.1'
+    implementation group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.1'
+    implementation group: 'javax.xml.ws', name: 'jaxws-api', version: '2.3.0'
     implementation group: 'javax.activation', name: 'activation', version: '1.1.1'
     implementation group: 'com.sun.xml.messaging.saaj', name: 'saaj-impl', version: '1.5.1'
 


### PR DESCRIPTION
This showed up when w3.org carried out tests on using a 302 redirect which the web service client could not follow. As a bonus, the onvif discovery is now much faster.