### PR TITLE
217 badly handled errors when cameracredentialsjson is not yet created

### DIFF
--- a/client/src/app/camera-params/camera-params.component.scss
+++ b/client/src/app/camera-params/camera-params.component.scss
@@ -20,4 +20,3 @@ div.camera-params-container
   display: flex;
   justify-content: space-between;
 }
-

--- a/client/src/app/cameras/camera.service.ts
+++ b/client/src/app/cameras/camera.service.ts
@@ -230,6 +230,11 @@ export class CameraService {
       catchError((err: HttpErrorResponse) => throwError(err)));
   }
 
+  haveCameraCredentials(): Observable<string> {
+    return this.http.post(this._baseUrl.getLink("cam", "haveCameraCredentials"), '',{responseType: 'text'}).pipe(
+      catchError((err: HttpErrorResponse) => throwError(err)));
+  }
+
   /**
    * loadCameraStreams: Get camera streams from the server
    */

--- a/client/src/app/config-setup/config-setup.component.html
+++ b/client/src/app/config-setup/config-setup.component.html
@@ -5,13 +5,13 @@
 <mat-card>
   <mat-card-title>Cameras Configuration
     <span
-      matTooltip="{{isGuest ? 'Disabled for guest' : 'Set or change the user name and password used to access the cameras. All cameras should have the same user name and password.'}}"
+      [matTooltip]="!haveCameraCredentials ? 'Camera credentials are not set, please enter a username and password. If your cameras do not use authentication for web admin or snapshots, this will not be required' : isGuest ? 'Disabled for guest' : 'Set or change the user name and password used to access the cameras. All cameras should have the same user name and password.'"
       matTooltipClass="tooltip">
       <button class="change-password-button"
               mat-icon-button
               [disabled]="isGuest"
               (click)="togglePasswordDialogue()">
-        <mat-icon>security</mat-icon>
+        <mat-icon [ngClass]="{'no-camera-credentials': !haveCameraCredentials}">security</mat-icon>
       </button>
     </span>
     <div class="password-dialogue">

--- a/client/src/app/config-setup/config-setup.component.scss
+++ b/client/src/app/config-setup/config-setup.component.scss
@@ -209,3 +209,18 @@ td.sort-buttons {
 mat-icon.sort-button-icon {
   font-size: 18px;
 }
+
+.no-camera-credentials {
+  animation: pulsing 1300ms infinite;
+}
+@keyframes pulsing {
+  0% {
+    color: #800;
+  }
+  50% {
+    color: #f66;
+  }
+  100% {
+    color: #800;
+  }
+}

--- a/client/src/app/config-setup/config-setup.component.ts
+++ b/client/src/app/config-setup/config-setup.component.ts
@@ -112,6 +112,7 @@ export class ConfigSetupComponent implements OnInit, AfterViewInit, OnDestroy {
   isGuest: boolean = true;
   gettingCameraDetails: boolean = false;
   savedDataHash: string = "";
+  haveCameraCredentials: boolean = false;
 
   constructor(public cameraSvc: CameraService, private utils: UtilsService, private sanitizer: DomSanitizer) {
   }
@@ -755,10 +756,19 @@ export class ConfigSetupComponent implements OnInit, AfterViewInit, OnDestroy {
     }
     return window.btoa(binary);
   }
+  private checkIfCameraCredentialsPresent() {
+    this.cameraSvc.haveCameraCredentials().subscribe(result => {
+        this.haveCameraCredentials = result == "true";
+      },
+      () => {
+        this.reporting.errorMessage = new HttpErrorResponse({error: "Couldn't determine if camera credentials are set."});
+      });
+  }
 
   togglePasswordDialogue() {
     this.showPasswordDialogue = !this.showPasswordDialogue;
     this.showAddCameraDialogue = false;
+    this.checkIfCameraCredentialsPresent();
   }
   toggleAddCameraOnvifUriDialogue() {
     this.showAddCameraDialogue =!this.showAddCameraDialogue;
@@ -801,6 +811,7 @@ export class ConfigSetupComponent implements OnInit, AfterViewInit, OnDestroy {
         this.reporting.errorMessage = new HttpErrorResponse({error: 'The configuration file is absent, empty or corrupt. Please set up the configuration for your cameras and save it.'});
         this.downloading = false;
       })
+    this.checkIfCameraCredentialsPresent();
     this.isGuest = this.utils.isGuestAccount;
   }
 

--- a/client/src/app/credentials-for-camera-access/credentials-for-camera-access.component.html
+++ b/client/src/app/credentials-for-camera-access/credentials-for-camera-access.component.html
@@ -10,8 +10,11 @@
                matTooltipClass="tooltip"
                placeholder="User name">
         <mat-hint>Admin user name for the cameras</mat-hint>
-        <mat-error *ngIf="setPasswordForm.controls['camerasUsername'].hasError('pattern')">5 or more characters and numbers</mat-error>
-        <mat-error *ngIf="setPasswordForm.controls['camerasUsername'].hasError('required')">User name is required</mat-error>
+        <mat-error *ngIf="setPasswordForm.controls['camerasUsername'].hasError('pattern')">5 or more characters and
+          numbers
+        </mat-error>
+        <mat-error *ngIf="setPasswordForm.controls['camerasUsername'].hasError('required')">User name is required
+        </mat-error>
       </mat-form-field>
     </div>
     <div>
@@ -21,13 +24,16 @@
                matTooltip="Enter the password for administrative access to the cameras. Note this is to give this application access to the cameras not to set it on the cameras."
                matTooltipClass="tooltip"
                placeholder="Password">
-               <mat-hint>Admin password for the cameras</mat-hint>
-        <mat-error *ngIf="setPasswordForm.controls['camerasPassword'].hasError('pattern')">Upper, lower case, numbers and special chars</mat-error>
-        <mat-error *ngIf="setPasswordForm.controls['camerasPassword'].hasError('required')">Password is required</mat-error>
+        <mat-hint>Admin password for the cameras</mat-hint>
+        <mat-error *ngIf="setPasswordForm.controls['camerasPassword'].hasError('pattern')">Upper, lower case, numbers
+          and special chars
+        </mat-error>
+        <mat-error *ngIf="setPasswordForm.controls['camerasPassword'].hasError('required')">Password is required
+        </mat-error>
       </mat-form-field>
     </div>
     <br>
-    <span class="cam-creds-confirm-group">
+    <span *ngIf="!updating" class="cam-creds-confirm-group">
       <button color="default" mat-flat-button (click)="hidePasswordDialogue()"
               matTooltip="Close this dialogue and leave the existing user name and password in place"
               matTooltipClass="tooltip">
@@ -40,6 +46,9 @@
               matTooltipClass="tooltip">
         Confirm
       </button>
+    </span>
+    <span *ngIf="updating" class="inline-spinner">
+      <mat-spinner [diameter]="25"></mat-spinner><span>Please wait..</span>
     </span>
   </mat-card-content>
 </mat-card>

--- a/client/src/app/credentials-for-camera-access/credentials-for-camera-access.component.scss
+++ b/client/src/app/credentials-for-camera-access/credentials-for-camera-access.component.scss
@@ -10,3 +10,10 @@
     margin-left: 0.5rem;
   }
 }
+
+.inline-spinner {
+  > mat-spinner {
+    margin-right: 10px;
+  }
+  display: flex;
+}

--- a/client/src/app/credentials-for-camera-access/credentials-for-camera-access.component.ts
+++ b/client/src/app/credentials-for-camera-access/credentials-for-camera-access.component.ts
@@ -24,6 +24,7 @@ export class CredentialsForCameraAccessComponent implements OnInit {
   camerasUsername: string = '';
   camerasPassword: string = '';
   setPasswordForm!: FormGroup;
+  updating: boolean = false;
 
 
   hidePasswordDialogue() {
@@ -37,12 +38,15 @@ export class CredentialsForCameraAccessComponent implements OnInit {
     let creds: CameraAdminCredentials = new CameraAdminCredentials();
     creds.camerasAdminPassword = this.camerasPassword;
     creds.camerasAdminUserName = this.camerasUsername;
+    this.updating = true;
     this.camSvc.setCameraAdminCredentials(creds).subscribe(() =>{
         this.hidePasswordDialogue();
         this.reporting.successMessage="Camera Access Credentials Updated";
+        this.updating = false;
     },
       (reason) => {
         this.reporting.errorMessage = reason;
+        this.updating = false;
       })
   }
 

--- a/fmp4-ws-media-server/config.go
+++ b/fmp4-ws-media-server/config.go
@@ -7,12 +7,13 @@ import (
 )
 
 type Config struct {
-	LogPath             string  `json:"log_path"`
-	LogLevelStr         string  `json:"log_level"`
-	CamerasJsonPath     string  `json:"cameras_json_path"`
-	ServerPort          int     `json:"server_port"`
-	DefaultLatencyLimit float32 `json:"default_latency_limit"`
-	GopCache            bool    `json:"gop_cache"`
+	LogPath               string  `json:"log_path"`
+	LogLevelStr           string  `json:"log_level"`
+	CamerasJsonPath       string  `json:"cameras_json_path"`
+	CameraCredentialsPath string  `json:"camera_credentials_path"`
+	ServerPort            int     `json:"server_port"`
+	DefaultLatencyLimit   float32 `json:"default_latency_limit"`
+	GopCache              bool    `json:"gop_cache"`
 }
 
 func (c *Config) LogLevel() (err error, level log.Level) {
@@ -94,28 +95,28 @@ func loadConfig() (config *Config, cameras *Cameras, credentials *CameraCredenti
 	}
 	data, err := os.ReadFile(exPath + "/config.json")
 	if err != nil {
-		log.Fatalln(err)
+		log.Errorln(err)
 	}
 	err = json.Unmarshal(data, &conf)
 	if err != nil {
-		log.Fatalln(err)
+		log.Errorln(err)
 	}
-	data, err = os.ReadFile("/var/security-cam/cameraCredentials.json")
+	data, err = os.ReadFile(conf.CameraCredentialsPath)
 	if err != nil {
-		log.Fatalln(err)
+		log.Errorln(err)
 	}
 	err = json.Unmarshal(data, &creds)
 	if err != nil {
-		log.Fatalln(err)
+		log.Errorln(err)
 	}
 
 	data, err = os.ReadFile(conf.CamerasJsonPath)
 	if err != nil {
-		log.Fatalln(err)
+		log.Errorln(err)
 	}
 	err = json.Unmarshal(data, &cams.Cameras)
 	if err != nil {
-		log.Fatalln(err)
+		log.Errorln(err)
 	}
 
 	config = &conf

--- a/fmp4-ws-media-server/config.json
+++ b/fmp4-ws-media-server/config.json
@@ -1,6 +1,7 @@
 {
   "log_path": "/var/log/fmp4-ws-media-service/fmp4-server.log",
   "cameras_json_path": "/var/security-cam/cameras.json",
+  "camera_credentials_path": "/var/security-cam/cameraCredentials.json",
   "log_level": "INFO",
   "server_port": 8085,
   "default_latency_limit": 0.8,

--- a/server/grails-app/controllers/server/CamController.groovy
+++ b/server/grails-app/controllers/server/CamController.groovy
@@ -155,4 +155,23 @@ class CamController {
                 render (status: 200, text: (response.responseObject as JSON))
         }
     }
+
+    @Secured(['ROLE_CLIENT', 'ROLE_CLOUD', 'ROLE_GUEST'])
+    def haveCameraCredentials() {
+        try {
+            String pw, un
+            pw = camService.cameraAdminPassword()
+            un = camService.cameraAdminUserName()
+
+            if (un == null || pw == null)
+                render(status: 200, text: "false")
+            else
+                render(status: 200, text: "true")
+        }
+        catch(Exception ex) {
+            String msg = "${ex.getClass().getName()} in haveCameraCredentials: ${ex.getMessage()}"
+            logService.getCam().error(msg)
+            render (status: 500, text: msg)
+        }
+    }
 }

--- a/server/grails-app/services/security/cam/CamService.groovy
+++ b/server/grails-app/services/security/cam/CamService.groovy
@@ -154,11 +154,19 @@ class CamService implements ICamServiceInterface{
     \"camerasAdminPassword\": \"${cmd.camerasAdminPassword}\"
 }
 """
+            // Stop media server etc
+            ObjectCommandResponse stopResult = sc_processesService.stopProcesses()
             String fileName = "${grailsApplication.config.camerasHomeDirectory}/cameraCredentials.json"
             BufferedWriter writer = new BufferedWriter(new FileWriter(fileName))
             writer.write(json)
-
             writer.close()
+            // Restart media server etc to pic]=k up new credentials
+            ObjectCommandResponse startResult = sc_processesService.startProcesses()
+
+            if(stopResult.status == PassFail.FAIL)
+                response = stopResult
+            else if (startResult.status == PassFail.FAIL)
+                response = startResult
         }
         catch (Exception ex) {
             logService.cam.error "setCameraAccessCredentials() caught " + ex.getClass().getName() + " with message = " + ex.getMessage()

--- a/server/grails-app/services/security/cam/OnvifService.groovy
+++ b/server/grails-app/services/security/cam/OnvifService.groovy
@@ -316,7 +316,7 @@ class OnvifService {
         ObjectCommandResponse resp = getSnapshotWithAuth(url, "")
 
         if(resp.errno == 401) {
-            Authentication auth = new Authentication(null)
+            Authentication auth = new Authentication(logService)
             String username = camService.cameraAdminUserName()
             String password = camService.cameraAdminPassword()
 

--- a/server/src/main/groovy/security/cam/audiobackchannel/NettyHttpAuthenticator.java
+++ b/server/src/main/groovy/security/cam/audiobackchannel/NettyHttpAuthenticator.java
@@ -38,7 +38,7 @@ public class NettyHttpAuthenticator extends ChannelDuplexHandler {
     private String challenge;
     private final String username;
     private final String password;
-    private ILogService logService;
+    private final ILogService logService;
 
     public NettyHttpAuthenticator(String username, String password, ILogService logService) {
         this.username = username;

--- a/server/src/main/groovy/security/cam/audiobackchannel/NettyHttpAuthenticator.java
+++ b/server/src/main/groovy/security/cam/audiobackchannel/NettyHttpAuthenticator.java
@@ -23,6 +23,7 @@
  */
 package security.cam.audiobackchannel;
 
+import com.proxy.ILogService;
 import common.Authentication;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandler;
@@ -37,11 +38,12 @@ public class NettyHttpAuthenticator extends ChannelDuplexHandler {
     private String challenge;
     private final String username;
     private final String password;
+    private ILogService logService;
 
-
-    public NettyHttpAuthenticator(String username, String password) {
+    public NettyHttpAuthenticator(String username, String password, ILogService logService) {
         this.username = username;
         this.password = password;
+        this.logService = logService;
     }
 
     @Override
@@ -67,7 +69,7 @@ public class NettyHttpAuthenticator extends ChannelDuplexHandler {
             String method = req.method().name();
             String uri = req.uri();
 
-            Authentication auth = new Authentication(null);
+            Authentication auth = new Authentication(logService);
             String header = auth.getAuthResponse(username, password, method, uri, challenge, new BasicHttpContext()).getValue();
             if (header != null) {
                 if (!header.contains("\"MD5\"") && header.contains("MD5"))

--- a/server/src/main/groovy/security/cam/audiobackchannel/RtspClient.groovy
+++ b/server/src/main/groovy/security/cam/audiobackchannel/RtspClient.groovy
@@ -73,7 +73,7 @@ class RtspClient {
                             p.addLast("encoder", new RtspEncoder())
                             p.addLast("decoder", new RtspDecoder())
                             p.addLast("aggregator", new HttpObjectAggregator(4 * 1024))
-                            p.addLast(new NettyHttpAuthenticator(username, password))
+                            p.addLast(new NettyHttpAuthenticator(username, password, logService))
                             p.addLast(handler)
                         }
                     })


### PR DESCRIPTION
- Fixed Badly handled errors when cameraCredentials.json is not yet created.
- Restart media service when credentials saved to force re-read. (if changing the credentials on the cameras, the configuration will need re-saving after updating the credentials on the NVR to ensure saving to the motion config files)
- Spinner on saving credentials as it now takes longer due to service restart.