### PR TITLE
Stage 6 any required fixes

### DIFF
--- a/server/grails-app/conf/application.yml
+++ b/server/grails-app/conf/application.yml
@@ -141,8 +141,8 @@ environments:
       trustStorePassword: B0331e
       cloudHost: 192.168.1.82
       cloudPort: 8081
-      webServerHost: localhost
-      webServerPort: 8088
+      webServerForCloudProxyHost: localhost
+      webServerForCloudProxyPort: 8088
       logLevel: ERROR
 
     nvrWebServer:
@@ -205,8 +205,8 @@ environments:
       trustStorePassword: B0331e
       cloudHost: 192.168.1.82
       cloudPort: 8081
-      webServerHost: localhost
-      webServerPort: 8088
+      webServerForCloudProxyHost: localhost
+      webServerForCloudProxyPort: 8088
       logLevel: INFO
 
     nvrWebServer:

--- a/server/grails-app/conf/application.yml
+++ b/server/grails-app/conf/application.yml
@@ -142,7 +142,7 @@ environments:
       cloudHost: 192.168.1.82
       cloudPort: 8081
       webServerHost: localhost
-      webServerPort: 8080
+      webServerPort: 8088
       logLevel: ERROR
 
     nvrWebServer:
@@ -203,10 +203,10 @@ environments:
       productKeyPath: /etc/security-cam/prodKey
       keyStorePassword: B0331e
       trustStorePassword: B0331e
-      cloudHost: 192.168.1.207
+      cloudHost: 192.168.1.82
       cloudPort: 8081
       webServerHost: localhost
-      webServerPort: 8080
+      webServerPort: 8088
       logLevel: INFO
 
     nvrWebServer:

--- a/server/grails-app/services/security/cam/CloudProxyService.groovy
+++ b/server/grails-app/services/security/cam/CloudProxyService.groovy
@@ -18,8 +18,8 @@ class CloudProxyService {
         if(cloudProxy == null)
         {
             cloudProxy = new CloudProxy(
-                    (String)(grailsApplication.config.cloudProxy.webServerHost),
-                    (Integer)(grailsApplication.config.cloudProxy.webServerPort),
+                    (String)(grailsApplication.config.cloudProxy.webServerForCloudProxyHost),
+                    (Integer)(grailsApplication.config.cloudProxy.webServerForCloudProxyPort),
                     (String)(grailsApplication.config.cloudProxy.cloudHost),
                     (Integer)(grailsApplication.config.cloudProxy.cloudPort))
         }

--- a/server/src/main/java/com/proxy/CloudProxy.java
+++ b/server/src/main/java/com/proxy/CloudProxy.java
@@ -533,8 +533,10 @@ public class CloudProxy implements SslContextProvider {
             buf.position(position);
             return token;
         }
-        else
+        else {
+            logger.error("getToken was called with buffer length less than "+Integer.BYTES+" ("+buf.limit()+")");
             return 0;
+        }
     }
 
     public long getCRC32Checksum(ByteBuffer buf) {

--- a/server/src/main/java/com/proxy/CloudProxy.java
+++ b/server/src/main/java/com/proxy/CloudProxy.java
@@ -40,8 +40,8 @@ public class CloudProxy implements SslContextProvider {
     final Queue<ByteBuffer> bufferQueue = new ConcurrentLinkedQueue<>();
     SSLSocket cloudChannel;
     private boolean running = false;
-    private final String webserverHost;
-    private final int webserverPort;
+    private final String webServerForCloudProxyHost;
+    private final int webServerForCloudProxyPort;
     private final String cloudHost;
     private final int cloudPort;
     CloudProxyProperties cloudProxyProperties = CloudProxyProperties.getInstance();
@@ -54,9 +54,9 @@ public class CloudProxy implements SslContextProvider {
     private ScheduledExecutorService cloudConnectionCheckExecutor;
     private ExecutorService startCloudInputProcessExecutor;
 
-    public CloudProxy(String webServerHost, int webServerPort, String cloudHost, int cloudPort) {
-        this.webserverHost = webServerHost;
-        this.webserverPort = webServerPort;
+    public CloudProxy(String webServerForCloudProxyHost, int webServerForCloudProxyPort, String cloudHost, int cloudPort) {
+        this.webServerForCloudProxyHost = webServerForCloudProxyHost;
+        this.webServerForCloudProxyPort = webServerForCloudProxyPort;
         this.cloudHost = cloudHost;
         this.cloudPort = cloudPort;
     }
@@ -338,7 +338,7 @@ public class CloudProxy implements SslContextProvider {
             } else  // Make a new connection to the webserver
             {
                 final SocketChannel webserverChannel = SocketChannel.open();
-                webserverChannel.connect(new InetSocketAddress(webserverHost, webserverPort));
+                webserverChannel.connect(new InetSocketAddress(webServerForCloudProxyHost, webServerForCloudProxyPort));
                 webserverChannel.configureBlocking(true);
                 tokenSocketMap.put(token, webserverChannel);
                 logger.debug("writeRequestToWebserver(1) length: " + getDataLengthFullRestore(buf));


### PR DESCRIPTION
    Fix crash in getToken when buffer length < Integer.BYTES.
    
    Change client side reference to CloudProxyController from CloudProxy to cloudProxy to prevent unknown URL in development environment.

    Commented out silenceremove.
    silenceremove prevents ffmpeg starting output until the input sound exceeds the given level. I'm not sure if this is helpful. Will need to reassess when I next have an audio backchannel device handy.

    Correct erroneous setting of cloudProxy -> webServerPort. Was 8080 now 8088. This parameter really needs to be renamed as its present name is confusing.

    getToken logs an error when buf.limit() < Integer.BYTES.

    Rename webServerHost to webServerForCloudProxyHost and webServerPort to webServerForCloudProxyPort for clarity.