### PR TITLE
Logging from ffmpeg feeding audio backchannel to security-cam.log.

### DIFF
--- a/client/src/app/video/video.component.ts
+++ b/client/src/app/video/video.component.ts
@@ -365,8 +365,19 @@ export class VideoComponent implements OnInit, AfterViewInit, OnDestroy {
         audio: (this.selectedAudioInput == null ? true : {deviceId: this.selectedAudioInput.deviceId}),
         video: false
       }).then((stream) => {
+        const mimeType = 'video/webm;codecs=vp8,opus';
         // @ts-ignore
-        this.recorder = new MediaRecorder(stream);
+        if (!MediaRecorder.isTypeSupported(mimeType)) {
+          alert('vp8/opus mime type is not supported');
+          return;
+        }
+        const options = {
+          audioBitsPerSecond: 48000,
+          mimeType,
+        }
+
+        // @ts-ignore
+        this.recorder = new MediaRecorder(stream, options);
         // fires every one second and passes a BlobEvent
         this.recorder.ondataavailable = (event: any) => {
           // get the Blob from the event
@@ -384,6 +395,11 @@ export class VideoComponent implements OnInit, AfterViewInit, OnDestroy {
             }
           });
         };
+
+        this.recorder.onstop = () => {
+          this.recorder.ondataavailable = undefined;
+          this.recorder.onstop = undefined;
+        }
 
         this.client.onConnect = () => this.recorder.start(100);
         this.client.activate();

--- a/server/grails-app/services/security/cam/UtilsService.groovy
+++ b/server/grails-app/services/security/cam/UtilsService.groovy
@@ -444,6 +444,7 @@ class UtilsService {
             try {
                 while (!audioQueue.empty) {
                     out.write(audioQueue.poll())
+                    Thread.sleep(3)
                     //   System.out.println("Writing ${audioQueue.poll().length} bytes")
                 }
             }

--- a/server/src/main/groovy/security/cam/audiobackchannel/RtspClient.groovy
+++ b/server/src/main/groovy/security/cam/audiobackchannel/RtspClient.groovy
@@ -98,6 +98,8 @@ class RtspClient {
                             // Start ffmpeg to transcode and transfer the audio data
                             List<String> command = new ArrayList()
                             command.add("/usr/local/bin/ffmpeg")
+                            command.add("-loglevel")
+                            command.add("info")
                             command.add("-i")
                             command.add("tcp://localhost:8881")
                             // silenceremove prevents ffmpeg starting output until the input sound exceeds the given level. I'm
@@ -117,6 +119,14 @@ class RtspClient {
                             // Left this comment here for future reference
 
                             audioOutProc = new ProcessBuilder(command).start()
+                            BufferedReader reader = audioOutProc.errorReader()
+                            String line
+                            new Thread().start(() -> {
+                                while ((line = reader.readLine()) != null) {
+                                    logService.getCam().info(line)
+                                }
+                            })
+
                             logService.getCam().info("RTSPClient ready, backchannel stream set up with ${h.getRTPAudioEncoding()}")
                             awaitLock.put(response)
                         }


### PR DESCRIPTION
3ms delay added after out.write(audioQueue.poll()) in the audio function.

In video component check vp8/opus mime type is supported, lower bitrate to 48000 (to hopefully improve reliability of backchannel), add onstop handler to MediaRecorder to clean up properly.