### PR TITLE
Modify cloud link to use activemq

### DIFF
--- a/client/src/app/cloud-proxy/cloud-proxy.component.ts
+++ b/client/src/app/cloud-proxy/cloud-proxy.component.ts
@@ -3,7 +3,6 @@ import {MatCheckboxChange} from '@angular/material/checkbox';
 import {CloudProxyService, IsMQConnected} from './cloud-proxy.service';
 import {ReportingComponent} from '../reporting/reporting.component';
 import {UtilsService} from '../shared/utils.service';
-import {Subscription, timer} from "rxjs";
 
 @Component({
   selector: 'app-cloud-proxy',

--- a/client/src/app/cloud-proxy/cloud-proxy.component.ts
+++ b/client/src/app/cloud-proxy/cloud-proxy.component.ts
@@ -40,11 +40,11 @@ export class CloudProxyComponent implements OnInit, OnDestroy {
   start(): void {
     this.cbEnabled = false;
     this.cpService.start().subscribe(() => {
-        this.utils.activeMQTransportActive = true; // Prevent warning flashing up before isTransportActive returns
-        this.cps = this.utils.cloudProxyRunning = true;
+
         this.cbEnabled = true;
         this.cpService.isTransportActive().subscribe((status: IsMQConnected) => {
           this.utils.activeMQTransportActive = status.transportActive;
+          this.cps = this.utils.cloudProxyRunning = true;
         });
       },
       (reason) => {

--- a/client/src/app/cloud-proxy/cloud-proxy.component.ts
+++ b/client/src/app/cloud-proxy/cloud-proxy.component.ts
@@ -41,6 +41,7 @@ export class CloudProxyComponent implements OnInit, OnDestroy {
   start(): void {
     this.cbEnabled = false;
     this.cpService.start().subscribe(() => {
+        this.utils.activeMQTransportActive = true; // Prevent warning flashing up before isTransportActive returns
         this.cps = this.utils.cloudProxyRunning = true;
         this.cbEnabled = true;
         this.cpService.isTransportActive().subscribe((status: IsMQConnected) => {

--- a/server/src/main/java/com/proxy/CloudAMQProxy.java
+++ b/server/src/main/java/com/proxy/CloudAMQProxy.java
@@ -116,11 +116,12 @@ public class CloudAMQProxy {
                 if (session != null)
                     session.close();
                 if (connection != null) {
-                    connection.close();
-                    connection.stop();
-
+                    if (connection.isStarted())
+                        connection.stop();
+                    if (!connection.isClosed())
+                        connection.close();
+                    closeAndClearSockets();
                 }
-                closeAndClearSockets();
             } catch (Exception ex) {
                 logger.error(ex.getClass().getName() + " in CloudAMQProxy.stop: " + ex.getMessage());
             } finally {
@@ -130,7 +131,7 @@ public class CloudAMQProxy {
     }
 
     public boolean isTransportActive() {
-        return connection != null &&  !connection.isClosed() && connection.isStarted() && transportActive;
+        return connection != null && !connection.isClosed() && connection.isStarted() && transportActive;
     }
 
     void closeAndClearSockets() {
@@ -359,7 +360,7 @@ public class CloudAMQProxy {
         connectionFactory.setTrustStore(cloudProxyProperties.getMQ_TRUSTSTORE_PATH());
         connectionFactory.setTrustStorePassword(cloudProxyProperties.getMQ_TRUSTSTORE_PASSWORD());
         // Create a Connection
-        ActiveMQConnection connection = (ActiveMQConnection)connectionFactory.createConnection(cloudProxyProperties.getMQ_USER(), cloudProxyProperties.getMQ_PASSWORD());
+        ActiveMQConnection connection = (ActiveMQConnection) connectionFactory.createConnection(cloudProxyProperties.getMQ_USER(), cloudProxyProperties.getMQ_PASSWORD());
         TransportListener tl = new TransportListener() {
             @Override
             public void onCommand(Object command) {


### PR DESCRIPTION
Set cloudProxyRunning to true in the subscribe callback for isTransportActive in CloudProxyComponent.start to prevent warning message flashing up in the interval before the status returns.