### PR TITLE
Modify cloud link to use activemq

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,8 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="JavadocDeclaration" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ADDITIONAL_TAGS" value="return:" />
+    </inspection_tool>
+  </profile>
+</component>

--- a/client/src/app/cloud-proxy/cloud-proxy.component.html
+++ b/client/src/app/cloud-proxy/cloud-proxy.component.html
@@ -1,5 +1,3 @@
-<app-reporting></app-reporting>
-
 <div class="cloud-proxy-box-container">
   <mat-card class="mat-elevation-z8" xmlns="http://www.w3.org/1999/html">
     <mat-card-title>Set Cloud Proxy Status</mat-card-title>
@@ -14,3 +12,5 @@
     </mat-card-content>
   </mat-card>
 </div>
+<app-reporting></app-reporting>
+

--- a/client/src/app/cloud-proxy/cloud-proxy.component.ts
+++ b/client/src/app/cloud-proxy/cloud-proxy.component.ts
@@ -4,7 +4,7 @@ import {CloudProxyService, IsMQConnected} from './cloud-proxy.service';
 import {ReportingComponent} from '../reporting/reporting.component';
 import {UtilsService} from '../shared/utils.service';
 import {Client, IMessage, StompSubscription} from "@stomp/stompjs";
-import {HttpErrorResponse, HttpResponse} from "@angular/common/http";
+import {HttpErrorResponse} from "@angular/common/http";
 
 @Component({
   selector: 'app-cloud-proxy',

--- a/client/src/app/cloud-proxy/cloud-proxy.component.ts
+++ b/client/src/app/cloud-proxy/cloud-proxy.component.ts
@@ -3,6 +3,8 @@ import {MatCheckboxChange} from '@angular/material/checkbox';
 import {CloudProxyService, IsMQConnected} from './cloud-proxy.service';
 import {ReportingComponent} from '../reporting/reporting.component';
 import {UtilsService} from '../shared/utils.service';
+import {Client, IMessage, StompSubscription} from "@stomp/stompjs";
+import {HttpErrorResponse, HttpResponse} from "@angular/common/http";
 
 @Component({
   selector: 'app-cloud-proxy',
@@ -13,7 +15,9 @@ export class CloudProxyComponent implements OnInit, OnDestroy {
   cps: boolean = true;
   cbEnabled: boolean = true;
   isGuest: boolean = true;
+  client!: Client;
   @ViewChild(ReportingComponent) reporting!: ReportingComponent;
+  private nvrloginstatusSubscription!: StompSubscription;
 
   constructor(private cpService: CloudProxyService, private utils: UtilsService) {
     cpService.getStatus().subscribe((status: boolean) => {
@@ -55,6 +59,40 @@ export class CloudProxyComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.isGuest = this.utils.isGuestAccount;
+    let serverUrl: string = (window.location.protocol == 'http:' ? 'ws://' : 'wss://') + window.location.host + '/stomp';
+    this.client = new Client({
+      brokerURL: serverUrl,
+      reconnectDelay: 2000,
+      heartbeatOutgoing: 120000,
+      heartbeatIncoming: 120000,
+      onConnect: () => {
+        this.nvrloginstatusSubscription = this.client.subscribe('/topic/nvrloginstatus', (message: IMessage) => {
+          if (message.body) {
+            let msgObj = JSON.parse(message.body);
+            switch (msgObj.status) {
+              case "working":
+                this.reporting.warningMessage = msgObj.message;
+                break;
+              case "success":
+                this.reporting.successMessage = msgObj.message;
+              break;
+              case "fail":
+                this.reporting.errorMessage = new HttpErrorResponse({error: msgObj.message});
+                break;
+              default:
+                this.reporting.errorMessage = new HttpErrorResponse({error: "Unknown message from server"});
+            }
+            if (msgObj.message === 'logoff' && this.isGuest) {
+              window.location.href = 'logoff';
+              console.log(message.body);
+            }
+          }
+        });
+      },
+      debug: () => {
+      }
+    });
+    this.client.activate();
   }
 
   setCloudProxyStatus($event: MatCheckboxChange) {
@@ -62,5 +100,6 @@ export class CloudProxyComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
+    this.nvrloginstatusSubscription.unsubscribe();
   }
 }


### PR DESCRIPTION
Login to cloud status messages when setting CloudProxy status to "on". This complements the transport status message (only for failure) that precedes it.