### PR TITLE
Stage 6 bucket brigade delay for triggered recordings

### DIFF
--- a/client/src/app/cameras/Camera.ts
+++ b/client/src/app/cameras/Camera.ts
@@ -71,6 +71,7 @@ export class Stream {
   video_height: number = 0;
   recording: Recording = new Recording();
   rec_num: number = 0;  // Used to give a rec number for the recording URI with motion triggered recordings
+  preambleFrames: number = 100;
 }
 export class CameraParamSpec {
   constructor(camType: cameraType, params: string, uri: string, name: string) {

--- a/client/src/app/cameras/camera.service.ts
+++ b/client/src/app/cameras/camera.service.ts
@@ -6,6 +6,7 @@ import {catchError, map, tap} from "rxjs/operators";
 import {AudioEncoding, Camera, CameraParamSpec, Stream} from "./Camera";
 import {CameraAdminCredentials} from "../credentials-for-camera-access/credentials-for-camera-access.component";
 import {NativeDateAdapter} from '@angular/material/core';
+import {KeyValue} from "@angular/common";
 
 
 /**
@@ -158,6 +159,19 @@ export class CameraService {
     return cameras;
   }
 
+  /**
+   * compareFn: Compare function for use with the keyvalue pipe. This compares string with numbers (such as stream9, stream10)
+   *            and sorts the numeric parts numerically rather than alphabetically. This was added to fix a bug which
+   *            occurred when there are 10 or more streams in total (like with 5 cameras, each having two streams).
+   * @param kv1 key1 camera1/stream1
+   * @param kv2 key2, camera2/stream2
+   */
+  compareFn(kv1: KeyValue<string, any>, kv2: KeyValue<string, any>): number {
+    return kv1.key.localeCompare(kv2.key, undefined, {
+      numeric: true,
+      sensitivity: 'base'
+    });
+  }
   /**
    * loadCameras: Get camera set up details from the server
    * @private

--- a/client/src/app/cameras/camera.service.ts
+++ b/client/src/app/cameras/camera.service.ts
@@ -108,6 +108,9 @@ export class CameraService {
     {name: "100", value: 100}
   ];
 
+  private _preambleFrameValues: number[] = [
+    0, 25, 50, 75, 100, 125, 150, 175, 200, 225, 250, 275, 300
+  ]
   get cameraParamSpecs() {
     return this._cameraParamSpecs;
   };
@@ -119,7 +122,9 @@ export class CameraService {
   get ftpRetriggerWindows() {
     return this._ftpRetriggerWindows;
   }
-
+  get preambleFrameValues() {
+    return this._preambleFrameValues;
+  }
   constructor(private http: HttpClient, private _baseUrl: BaseUrl) {
     this.loadCameras().subscribe((cams) => {
       this.cameras = cams;

--- a/client/src/app/config-setup/config-setup.component.html
+++ b/client/src/app/config-setup/config-setup.component.html
@@ -25,6 +25,7 @@
       </div>
     </div>
   </mat-card-title>
+  <app-reporting #errorReporting></app-reporting>
   <mat-card-content class="wait-box mat-form-field-flex" *ngIf="downloading">
     <mat-spinner [diameter]="25"></mat-spinner>
     <span>Loading, Please wait..</span>
@@ -37,7 +38,7 @@
     <mat-spinner [diameter]="25"></mat-spinner>
     <span>Camera discovery active, Please wait..</span>
   </mat-card-content>
-  <mat-card-content class="scrollable-content" *ngIf="!downloading  && !updating && !discovering">
+  <mat-card-content #scrollable_content [style]="getScrollableContentStyle()" *ngIf="!downloading  && !updating && !discovering">
     <table mat-table
            [dataSource]="cameras | keyvalue" multiTemplateDataRows
            class="mat-elevation-z8">
@@ -634,4 +635,4 @@
   </mat-card-content>
 </mat-card>
 
-<app-reporting #errorReporting></app-reporting>
+

--- a/client/src/app/config-setup/config-setup.component.html
+++ b/client/src/app/config-setup/config-setup.component.html
@@ -37,7 +37,7 @@
     <mat-spinner [diameter]="25"></mat-spinner>
     <span>Camera discovery active, Please wait..</span>
   </mat-card-content>
-  <mat-card-content style="width: calc(100dvw - 30px); height: calc(100dvh - 140px);  overflow: scroll" *ngIf="!downloading  && !updating && !discovering">
+  <mat-card-content class="scrollable-content" *ngIf="!downloading  && !updating && !discovering">
     <table mat-table
            [dataSource]="cameras | keyvalue" multiTemplateDataRows
            class="mat-elevation-z8">

--- a/client/src/app/config-setup/config-setup.component.html
+++ b/client/src/app/config-setup/config-setup.component.html
@@ -37,7 +37,7 @@
     <mat-spinner [diameter]="25"></mat-spinner>
     <span>Camera discovery active, Please wait..</span>
   </mat-card-content>
-  <mat-card-content *ngIf="!downloading  && !updating && !discovering">
+  <mat-card-content style="width: calc(100dvw - 30px); height: calc(100dvh - 140px);  overflow: scroll" *ngIf="!downloading  && !updating && !discovering">
     <table mat-table
            [dataSource]="cameras | keyvalue" multiTemplateDataRows
            class="mat-elevation-z8">
@@ -142,7 +142,7 @@
           <mat-checkbox [formControl]="getCamControl(i, 'ftp')"
                         [disabled]="getFTPDisabledState(cam.value)"
                         matTooltip="{{motionSet(cam.value) ? 'To use FTP upload from the camera, you must not have motion selected on any stream.' :
-                        'If checked, make event recordings sent by FTP from '+ cam.key + ' available in the recordings selection.'}}"
+                        'If checked, images sent by FTP from '+ cam.key + ' on motion being detected will trigger the NVR to make a recording on the HD stream of that camera. These recordings will be available on the Select Recording menu. The camera should be set to FTP to ./'+cam.key+ 'on port 2121 of the NVR. See Camera Recordings Service section of the README.md'}}"
                         matTooltipClass="tooltip"
                         (change)="updateCamField(i, 'ftp')">
           </mat-checkbox>
@@ -427,6 +427,22 @@
                         *ngFor="let camStream of cam.value.streams | keyvalue | excludeOwnStream:stream.key"
                         [value]="cam.key+'.'+camStream.key">
                         {{camStream.key}}
+                      </mat-option>
+                    </mat-select>
+                  </mat-form-field>
+                </td>
+              </ng-container>
+              <ng-container matColumnDef="preambleFrames">
+                <th mat-header-cell *matHeaderCellDef>Preamble Frames.</th>
+                <td mat-cell *matCellDef="let stream; let streamIndex = index">
+                  <mat-form-field appearance="legacy" [style.width.px]="50">
+                    <mat-select [formControl]="getStreamControl(camIndex, streamIndex, 'preambleFrames')"
+                                (selectionChange)="updateStreamField(camIndex, streamIndex, 'preambleFrames')"
+                                [disabled]="getPreambleFramesDisabledState(cam.value, stream.value)"
+                                matTooltip="The number of frames to delay the video stream by when recording. The value selected will give a preamble to recordings (time prior to when the recording was triggered) of this value divided by thje camera frame rate (seconds)."
+                                matTooltipClass="tooltip">
+                      <mat-option *ngFor="let preamble of cameraSvc.preambleFrameValues" [value]="preamble">
+                        {{preamble}}
                       </mat-option>
                     </mat-select>
                   </mat-form-field>

--- a/client/src/app/config-setup/config-setup.component.html
+++ b/client/src/app/config-setup/config-setup.component.html
@@ -9,7 +9,7 @@
       matTooltipClass="tooltip">
       <button class="change-password-button"
               mat-icon-button
-              [attr.disabled]="isGuest"
+              [disabled]="isGuest"
               (click)="togglePasswordDialogue()">
         <mat-icon [ngClass]="{'no-camera-credentials': !haveCameraCredentials}">security</mat-icon>
       </button>
@@ -48,14 +48,14 @@
             class="sort-buttons"
             *matCellDef="let cam">
           <span>
-            <button [attr.disabled]="lastElement(cam) || anyInvalid() || confirmNew || confirmNewLookup || isGuest"
+            <button [disabled]="lastElement(cam) || anyInvalid() || confirmNew || confirmNewLookup || isGuest"
                     mat-icon-button (click)="moveDown(cam)"
                     [matTooltip]="lastElement(cam) ? '' : 'Click to move '+cam.value.name+' down 1 step'"
                     matTooltipClass="tooltip"
                     class="sort-button-icon">
               <mat-icon class="sort-button-icon">arrow_downward</mat-icon>
             </button>
-            <button [attr.disabled]="cam.key=='camera1' || anyInvalid() || confirmNew || confirmNewLookup || isGuest"
+            <button [disabled]="cam.key=='camera1' || anyInvalid() || confirmNew || confirmNewLookup || isGuest"
                     mat-icon-button (click)="moveUp(cam)"
                     [matTooltip]="cam.key=='camera1' ? '' : 'Click to move '+cam.value.name+' up 1 step'"
                     matTooltipClass="tooltip"
@@ -88,7 +88,7 @@
         <th mat-header-cell *matHeaderCellDef>Delete</th>
         <td mat-cell *matCellDef="let cam">
           <button mat-icon-button matTooltip="Delete {{cam.key}}" matTooltipClass="tooltip"
-                  [attr.disabled]="cameras.size <= 1 || confirmSave || confirmNew"
+                  [disabled]="cameras.size <= 1 || confirmSave || confirmNew"
                   (click)="deleteCamera(cam.key)">
             <mat-icon>delete</mat-icon>
           </button>
@@ -141,7 +141,7 @@
         <th mat-header-cell *matHeaderCellDef>FTP From Camera.</th>
         <td mat-cell *matCellDef="let cam; let i = dataIndex">
           <mat-checkbox [formControl]="getCamControl(i, 'ftp')"
-                        [attr.disabled]="getFTPDisabledState(cam.value)"
+                        [disabled]="getFTPDisabledState(cam.value)"
                         matTooltip="{{motionSet(cam.value) ? 'To use FTP upload from the camera, you must not have motion selected on any stream.' :
                         'If checked, images sent by FTP from '+ cam.key + ' on motion being detected will trigger the NVR to make a recording on the HD stream of that camera. These recordings will be available on the Select Recording menu. The camera should be set to FTP to ./'+cam.key+ 'on port 2121 of the NVR. See Camera Recordings Service section of the README.md'}}"
                         matTooltipClass="tooltip"
@@ -156,7 +156,7 @@
           <mat-form-field appearance="legacy" [style.width.px]="50">
             <mat-select [formControl]="getCamControl(i, 'retriggerWindow')"
                         (selectionChange)="updateCamField(i, 'retriggerWindow')"
-                        [attr.disabled]="!cam.value.ftp"
+                        [disabled]="!cam.value.ftp"
                         matTooltip="Select the maximum time in seconds that can elapse between FTP uploads from the camere for the recording to be extended further by this selected time. The absence of another FTP within this window will result in the recording being completed."
                         matTooltipClass="tooltip">
               <mat-option *ngFor="let win of cameraSvc.ftpRetriggerWindows" [value]="win.value">
@@ -243,7 +243,7 @@
         <th mat-header-cell *matHeaderCellDef>PTZ Controls.</th>
         <td mat-cell *matCellDef="let cam; let i = dataIndex">
           <mat-checkbox [formControl]="getCamControl(i, 'ptzControls')"
-                        [attr.disabled]="setPTZControlsCheckboxDisabledState(i)"
+                        [disabled]="setPTZControlsCheckboxDisabledState(i)"
                         matTooltip="The Pan Tilt and Zoom controls for {{cam.key}} will be present on the live stream view if checked."
                         matTooltipClass="tooltip"
                         (change)="updateCamField(i, 'ptzControls')">
@@ -283,7 +283,7 @@
                 <th mat-header-cell *matHeaderCellDef>Delete</th>
                 <td mat-cell *matCellDef="let stream" [width]="50">
                   <button mat-icon-button matTooltip="Delete this stream" matTooltipClass="tooltip"
-                          [attr.disabled]="(cam.value.streams.size <= 1) || confirmSave || confirmNew"
+                          [disabled]="(cam.value.streams.size <= 1) || confirmSave || confirmNew"
                           (click)="deleteStream(cam.key, stream.key)">
                     <mat-icon>delete</mat-icon>
                   </button>
@@ -314,7 +314,7 @@
                 <td mat-cell *matCellDef="let stream; let streamIndex = index">
                   <mat-checkbox [color]="'primary'" [checked]="stream.value.audio"
                                 (change)="setAudioInEnabledStatus($event, stream.value)"
-                                [attr.disabled]="stream.value.audio_encoding == 'None'"
+                                [disabled]="stream.value.audio_encoding == 'None'"
                                 matTooltip="If checked, audio will be enabled on {{stream.key}} for {{cam.key}}."
                                 matTooltipClass="tooltip">
                   </mat-checkbox>

--- a/client/src/app/config-setup/config-setup.component.html
+++ b/client/src/app/config-setup/config-setup.component.html
@@ -9,7 +9,7 @@
       matTooltipClass="tooltip">
       <button class="change-password-button"
               mat-icon-button
-              [disabled]="isGuest"
+              [attr.disabled]="isGuest"
               (click)="togglePasswordDialogue()">
         <mat-icon [ngClass]="{'no-camera-credentials': !haveCameraCredentials}">security</mat-icon>
       </button>
@@ -40,7 +40,7 @@
   </mat-card-content>
   <mat-card-content #scrollable_content [style]="getScrollableContentStyle()" *ngIf="!downloading  && !updating && !discovering">
     <table mat-table
-           [dataSource]="cameras | keyvalue" multiTemplateDataRows
+           [dataSource]="cameras | keyvalue: cameraSvc.compareFn" multiTemplateDataRows
            class="mat-elevation-z8">
       <ng-container matColumnDef="sorting">
         <th mat-header-cell *matHeaderCellDef>Sorting</th>
@@ -48,14 +48,14 @@
             class="sort-buttons"
             *matCellDef="let cam">
           <span>
-            <button [disabled]="lastElement(cam) || anyInvalid() || confirmNew || confirmNewLookup || isGuest"
+            <button [attr.disabled]="lastElement(cam) || anyInvalid() || confirmNew || confirmNewLookup || isGuest"
                     mat-icon-button (click)="moveDown(cam)"
                     [matTooltip]="lastElement(cam) ? '' : 'Click to move '+cam.value.name+' down 1 step'"
                     matTooltipClass="tooltip"
                     class="sort-button-icon">
               <mat-icon class="sort-button-icon">arrow_downward</mat-icon>
             </button>
-            <button [disabled]="cam.key=='camera1' || anyInvalid() || confirmNew || confirmNewLookup || isGuest"
+            <button [attr.disabled]="cam.key=='camera1' || anyInvalid() || confirmNew || confirmNewLookup || isGuest"
                     mat-icon-button (click)="moveUp(cam)"
                     [matTooltip]="cam.key=='camera1' ? '' : 'Click to move '+cam.value.name+' up 1 step'"
                     matTooltipClass="tooltip"
@@ -88,7 +88,7 @@
         <th mat-header-cell *matHeaderCellDef>Delete</th>
         <td mat-cell *matCellDef="let cam">
           <button mat-icon-button matTooltip="Delete {{cam.key}}" matTooltipClass="tooltip"
-                  [disabled]="cameras.size <= 1 || confirmSave || confirmNew"
+                  [attr.disabled]="cameras.size <= 1 || confirmSave || confirmNew"
                   (click)="deleteCamera(cam.key)">
             <mat-icon>delete</mat-icon>
           </button>
@@ -141,7 +141,7 @@
         <th mat-header-cell *matHeaderCellDef>FTP From Camera.</th>
         <td mat-cell *matCellDef="let cam; let i = dataIndex">
           <mat-checkbox [formControl]="getCamControl(i, 'ftp')"
-                        [disabled]="getFTPDisabledState(cam.value)"
+                        [attr.disabled]="getFTPDisabledState(cam.value)"
                         matTooltip="{{motionSet(cam.value) ? 'To use FTP upload from the camera, you must not have motion selected on any stream.' :
                         'If checked, images sent by FTP from '+ cam.key + ' on motion being detected will trigger the NVR to make a recording on the HD stream of that camera. These recordings will be available on the Select Recording menu. The camera should be set to FTP to ./'+cam.key+ 'on port 2121 of the NVR. See Camera Recordings Service section of the README.md'}}"
                         matTooltipClass="tooltip"
@@ -156,7 +156,7 @@
           <mat-form-field appearance="legacy" [style.width.px]="50">
             <mat-select [formControl]="getCamControl(i, 'retriggerWindow')"
                         (selectionChange)="updateCamField(i, 'retriggerWindow')"
-                        [disabled]="!cam.value.ftp"
+                        [attr.disabled]="!cam.value.ftp"
                         matTooltip="Select the maximum time in seconds that can elapse between FTP uploads from the camere for the recording to be extended further by this selected time. The absence of another FTP within this window will result in the recording being completed."
                         matTooltipClass="tooltip">
               <mat-option *ngFor="let win of cameraSvc.ftpRetriggerWindows" [value]="win.value">
@@ -243,7 +243,7 @@
         <th mat-header-cell *matHeaderCellDef>PTZ Controls.</th>
         <td mat-cell *matCellDef="let cam; let i = dataIndex">
           <mat-checkbox [formControl]="getCamControl(i, 'ptzControls')"
-                        [disabled]="setPTZControlsCheckboxDisabledState(i)"
+                        [attr.disabled]="setPTZControlsCheckboxDisabledState(i)"
                         matTooltip="The Pan Tilt and Zoom controls for {{cam.key}} will be present on the live stream view if checked."
                         matTooltipClass="tooltip"
                         (change)="updateCamField(i, 'ptzControls')">
@@ -271,7 +271,7 @@
         <td mat-cell *matCellDef="let cam; let camIndex=dataIndex" [attr.colspan]="cameraColumns.length">
           <div class="element-detail mat-elevation-z10"
                [@detailExpand]="cam.value == expandedElement ? 'expanded' : 'collapsed'">
-            <table mat-table [dataSource]="cam.value.streams | keyvalue" class="streams-info mat-elevation-z10">
+            <table mat-table [dataSource]="cam.value.streams | keyvalue: cameraSvc.compareFn" class="streams-info mat-elevation-z10">
               <ng-container matColumnDef="stream_id">
                 <th mat-header-cell *matHeaderCellDef>Stream ID</th>
                 <td mat-cell *matCellDef="let stream" [width]="60"
@@ -283,7 +283,7 @@
                 <th mat-header-cell *matHeaderCellDef>Delete</th>
                 <td mat-cell *matCellDef="let stream" [width]="50">
                   <button mat-icon-button matTooltip="Delete this stream" matTooltipClass="tooltip"
-                          [disabled]="(cam.value.streams.size <= 1) || confirmSave || confirmNew"
+                          [attr.disabled]="(cam.value.streams.size <= 1) || confirmSave || confirmNew"
                           (click)="deleteStream(cam.key, stream.key)">
                     <mat-icon>delete</mat-icon>
                   </button>
@@ -314,7 +314,7 @@
                 <td mat-cell *matCellDef="let stream; let streamIndex = index">
                   <mat-checkbox [color]="'primary'" [checked]="stream.value.audio"
                                 (change)="setAudioInEnabledStatus($event, stream.value)"
-                                [disabled]="stream.value.audio_encoding == 'None'"
+                                [attr.disabled]="stream.value.audio_encoding == 'None'"
                                 matTooltip="If checked, audio will be enabled on {{stream.key}} for {{cam.key}}."
                                 matTooltipClass="tooltip">
                   </mat-checkbox>
@@ -425,7 +425,7 @@
                         None
                       </mat-option>
                       <mat-option
-                        *ngFor="let camStream of cam.value.streams | keyvalue | excludeOwnStream:stream.key"
+                        *ngFor="let camStream of cam.value.streams | keyvalue: cameraSvc.compareFn | excludeOwnStream:stream.key"
                         [value]="cam.key+'.'+camStream.key">
                         {{camStream.key}}
                       </mat-option>

--- a/client/src/app/config-setup/config-setup.component.scss
+++ b/client/src/app/config-setup/config-setup.component.scss
@@ -213,6 +213,7 @@ mat-icon.sort-button-icon {
 .no-camera-credentials {
   animation: pulsing 1300ms infinite;
 }
+
 @keyframes pulsing {
   0% {
     color: #800;
@@ -223,4 +224,32 @@ mat-icon.sort-button-icon {
   100% {
     color: #800;
   }
+}
+mat-card-content.scrollable-content {
+  width: calc(100dvw - 30px);
+  height: calc(100dvh - 140px);
+  overflow: auto;
+}
+::-webkit-scrollbar {
+  width: 15px;
+  height: 15px;
+}
+
+::-webkit-scrollbar-track {
+  box-shadow: inset 0 0 5px grey;
+  border-radius: 10px;
+}
+
+::-webkit-scrollbar-thumb {
+  background: #626262;
+  border-radius: 10px;
+}
+
+/* Handle on hover */
+::-webkit-scrollbar-thumb:hover {
+  background: #8f8f8f;
+}
+
+::-webkit-scrollbar-corner {
+  background-color: inherit;
 }

--- a/client/src/app/config-setup/config-setup.component.scss
+++ b/client/src/app/config-setup/config-setup.component.scss
@@ -225,11 +225,7 @@ mat-icon.sort-button-icon {
     color: #800;
   }
 }
-mat-card-content.scrollable-content {
-  width: calc(100dvw - 30px);
-  height: calc(100dvh - 140px);
-  overflow: auto;
-}
+
 ::-webkit-scrollbar {
   width: 15px;
   height: 15px;
@@ -245,7 +241,6 @@ mat-card-content.scrollable-content {
   border-radius: 10px;
 }
 
-/* Handle on hover */
 ::-webkit-scrollbar-thumb:hover {
   background: #8f8f8f;
 }

--- a/client/src/app/config-setup/config-setup.component.ts
+++ b/client/src/app/config-setup/config-setup.component.ts
@@ -87,6 +87,7 @@ export function validateTrueOrFalse(fieldCondition: {}): ValidatorFn {
 export class ConfigSetupComponent implements OnInit, AfterViewInit, OnDestroy {
   @ViewChild('errorReporting') reporting!: ReportingComponent;
   @ViewChild('outputframeid') snapshotImage!: ElementRef<HTMLImageElement>
+  @ViewChild('scrollable_content') scrollableContent!: ElementRef<HTMLElement>
   downloading: boolean = true;
   updating: boolean = false;
   discovering: boolean = false;
@@ -815,6 +816,15 @@ export class ConfigSetupComponent implements OnInit, AfterViewInit, OnDestroy {
     cam.backchannelAudioSupported = !cam.backchannelAudioSupported;
   }
 
+  getScrollableContentStyle():string {
+    const scrollableContent = this.scrollableContent?.nativeElement;
+
+    if(scrollableContent !== undefined ) {
+      const boundingRect = scrollableContent.getBoundingClientRect()
+      return 'width: 100%; height: calc(100dvh - ${boundingRect.top+20}px); overflow: auto;'
+    }
+    else return ""
+  }
   ngOnInit(): void {
     // Set up the available streams/cameras for selection by the checkboxes
     this.cameraSvc.loadCameras().subscribe(cameras => {

--- a/client/src/app/config-setup/config-setup.component.ts
+++ b/client/src/app/config-setup/config-setup.component.ts
@@ -842,9 +842,9 @@ export class ConfigSetupComponent implements OnInit, AfterViewInit, OnDestroy {
     this.cameraSvc.loadCameras().subscribe(cameras => {
         this.cameras = cameras;
 
-        this.savedDataHash = objectHash(this.cameras);
         this.downloading = false;
         this.FixUpCamerasData()
+        this.savedDataHash = objectHash(this.cameras);
       },
       () => {
         this.createNew();

--- a/client/src/app/config-setup/config-setup.component.ts
+++ b/client/src/app/config-setup/config-setup.component.ts
@@ -95,7 +95,7 @@ export class ConfigSetupComponent implements OnInit, AfterViewInit, OnDestroy {
   cameraFooterColumns = ['buttons'];
 
   expandedElement!: Camera | null;
-  streamColumns = ['stream_id', 'delete', 'descr', 'audio', 'audio_encoding', 'netcam_uri', 'defaultOnMultiDisplay', 'motion', 'threshold', 'trigger_recording_on', 'mask_file', 'video_width', 'video_height'];
+  streamColumns = ['stream_id', 'delete', 'descr', 'audio', 'audio_encoding', 'netcam_uri', 'defaultOnMultiDisplay', 'motion', 'threshold', 'trigger_recording_on', 'preambleFrames', 'mask_file', 'video_width', 'video_height'];
   streamFooterColumns = ['buttons']
 //  camSetupFormGroup!: FormGroup;
   camControls!: FormArray;
@@ -128,6 +128,9 @@ export class ConfigSetupComponent implements OnInit, AfterViewInit, OnDestroy {
     if (ovhc.value == '')
       ptzc.setValue(false);  // Ensure PTZ is set to "off" if onvifHost has the (valid) value empty
     return ovhc.value == '' || !ovhc.valid;
+  }
+  getPreambleFramesDisabledState(cam: Camera, stream: Stream): boolean {
+    return !stream?.motion?.enabled && !cam?.ftp;
   }
 
   updateCam(index: number, field: string, value: any) {
@@ -236,6 +239,10 @@ export class ConfigSetupComponent implements OnInit, AfterViewInit, OnDestroy {
             value: stream.motion.trigger_recording_on,
             disabled: !stream.motion.enabled
           }, [Validators.nullValidator]),
+          preambleFrames: new FormControl({
+            value: stream.preambleFrames,
+            disabled: this.getPreambleFramesDisabledState(camera, stream),
+          }, [Validators.min(0), Validators.max(300)]),
           mask_file: new FormControl({
             value: stream.motion.mask_file,
             disabled: !stream.motion.enabled

--- a/client/src/app/config-setup/config-setup.component.ts
+++ b/client/src/app/config-setup/config-setup.component.ts
@@ -652,6 +652,7 @@ export class ConfigSetupComponent implements OnInit, AfterViewInit, OnDestroy {
         this.updating = false;
         // Update the saved data hash
         this.savedDataHash = objectHash(this.cameras);
+        this.cd.detectChanges();
       },
       reason => {
         this.reporting.errorMessage = reason
@@ -676,8 +677,8 @@ export class ConfigSetupComponent implements OnInit, AfterViewInit, OnDestroy {
     this.discovering = true;
     this.cameraSvc.discover().subscribe((cams: Map<string, Camera>) => {
         this.cameras = cams;
-        this.FixUpCamerasData();
         this.discovering = false;
+        this.FixUpCamerasData();
       },
       reason => {
         this.reporting.errorMessage = reason;
@@ -840,9 +841,10 @@ export class ConfigSetupComponent implements OnInit, AfterViewInit, OnDestroy {
     // Set up the available streams/cameras for selection by the checkboxes
     this.cameraSvc.loadCameras().subscribe(cameras => {
         this.cameras = cameras;
-        this.FixUpCamerasData()
+
         this.savedDataHash = objectHash(this.cameras);
         this.downloading = false;
+        this.FixUpCamerasData()
       },
       () => {
         this.createNew();

--- a/client/src/app/config-setup/config-setup.component.ts
+++ b/client/src/app/config-setup/config-setup.component.ts
@@ -1,4 +1,13 @@
-import {AfterViewInit, Component, ElementRef, isDevMode, OnDestroy, OnInit, ViewChild} from '@angular/core';
+import {
+  AfterViewInit,
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  isDevMode,
+  OnDestroy,
+  OnInit,
+  ViewChild
+} from '@angular/core';
 import {CameraService} from '../cameras/camera.service';
 import {Camera, CameraParamSpec, Stream} from "../cameras/Camera";
 import {ReportingComponent} from '../reporting/reporting.component';
@@ -115,7 +124,7 @@ export class ConfigSetupComponent implements OnInit, AfterViewInit, OnDestroy {
   savedDataHash: string = "";
   haveCameraCredentials: boolean = false;
 
-  constructor(public cameraSvc: CameraService, private utils: UtilsService, private sanitizer: DomSanitizer) {
+  constructor(public cameraSvc: CameraService, private utils: UtilsService, private sanitizer: DomSanitizer, private cd: ChangeDetectorRef) {
   }
 
   getCamControl(index: number, fieldName: string): FormControl {
@@ -468,6 +477,7 @@ export class ConfigSetupComponent implements OnInit, AfterViewInit, OnDestroy {
 
     this.cameras = retVal;
     this.setUpTableFormControls();
+    this.cd.detectChanges();  // Fixes bug where the doorbell would come up with the wrong stream selected for motion after onvif discovery
   }
 
   toggle(el: { key: string, value: Camera }) {

--- a/client/src/app/config-setup/config-setup.component.ts
+++ b/client/src/app/config-setup/config-setup.component.ts
@@ -821,10 +821,11 @@ export class ConfigSetupComponent implements OnInit, AfterViewInit, OnDestroy {
 
     if(scrollableContent !== undefined ) {
       const boundingRect = scrollableContent.getBoundingClientRect()
-      return 'width: 100%; height: calc(100dvh - ${boundingRect.top+20}px); overflow: auto;'
+      return `width: 100%; height: calc(100dvh - ${boundingRect.top+20}px); overflow: auto;`
     }
     else return ""
   }
+
   ngOnInit(): void {
     // Set up the available streams/cameras for selection by the checkboxes
     this.cameraSvc.loadCameras().subscribe(cameras => {

--- a/client/src/app/multi-cam-view/multi-cam-view.component.html
+++ b/client/src/app/multi-cam-view/multi-cam-view.component.html
@@ -15,7 +15,7 @@
         </mat-card-title>
 
         <mat-card-content>
-          <table mat-table [dataSource]="cams | keyvalue" multiTemplateDataRows class="mat-elevation-z8">
+          <table mat-table [dataSource]="cams | keyvalue: cameraSvc.compareFn" multiTemplateDataRows class="mat-elevation-z8">
             <ng-container matColumnDef="name">
               <th mat-header-cell *matHeaderCellDef>Camera</th>
               <td mat-cell *matCellDef="let cam">{{cam.value.name}}</td>
@@ -37,7 +37,7 @@
               <td mat-cell *matCellDef="let cam" [attr.colspan]="cameraColumns.length">
                 <div class="element-detail mat-elevation-z10"
                      [@detailExpand]="cam.value == expandedElement ? 'expanded' : 'collapsed'">
-                  <table mat-table [dataSource]="cam.value.streams | keyvalue"
+                  <table mat-table [dataSource]="cam.value.streams | keyvalue: cameraSvc.compareFn"
                          class="streams-info mat-elevation-z10">
                     <ng-container matColumnDef="select">
                       <th mat-header-cell *matHeaderCellDef>Select Stream To Display</th>
@@ -76,7 +76,7 @@
 </div>
 <app-reporting></app-reporting>
 <div class="flex-container-vid">
-  <ng-container *ngFor="let cam of cams | keyvalue">
+  <ng-container *ngFor="let cam of cams | keyvalue: cameraSvc.compareFn">
     <app-video [isFmp4]="true"></app-video>
   </ng-container>
 </div>

--- a/client/src/app/multi-cam-view/multi-cam-view.component.ts
+++ b/client/src/app/multi-cam-view/multi-cam-view.component.ts
@@ -44,7 +44,7 @@ export class MultiCamViewComponent implements OnInit, AfterViewInit, OnDestroy {
   cameraColumns = ['name', 'expand'];
   streamColumns = ['select'];
 
-  constructor(private cameraSvc: CameraService, private utilsService: UtilsService) {
+  constructor(public cameraSvc: CameraService, private utilsService: UtilsService) {
   }
 
   cams: Map<string, Camera> = new Map<string, Camera>();

--- a/client/src/app/multi-cam-view/multi-cam-view.component.ts
+++ b/client/src/app/multi-cam-view/multi-cam-view.component.ts
@@ -111,9 +111,9 @@ export class MultiCamViewComponent implements OnInit, AfterViewInit, OnDestroy {
   /**
    * updateCameras Respond to check box clicks to select/unselect streams. This also ensures
    *               that only one stream (HD or Low Res) can be selected at one time
-   * @param $event: MatCheckbox change event including selected attribute
-   * @param camera: The current camera the stream is on
-   * @param stream: The stream on which the selection is being made
+   * @param $event MatCheckbox change event including selected attribute
+   * @param camera The current camera the stream is on
+   * @param stream The stream on which the selection is being made
    */
   updateCameras($event: MatCheckboxChange, camera: Camera, stream: Stream) {
     if (stream.selected) {

--- a/client/src/app/nav/nav.component.html
+++ b/client/src/app/nav/nav.component.html
@@ -18,8 +18,8 @@
         Select Camera
       </button>
       <mat-menu #menuSelectCamera="matMenu">
-        <ng-container *ngFor="let camKV of cameras | keyvalue">
-          <ng-container *ngFor="let streamKV of camKV.value.streams | keyvalue">
+        <ng-container *ngFor="let camKV of cameras | keyvalue: cameraSvc.compareFn">
+          <ng-container *ngFor="let streamKV of camKV.value.streams | keyvalue: cameraSvc.compareFn">
             <button mat-menu-item (click)="setVideoStream(camKV.value, streamKV.value);menuClosed()">
               {{camKV.value.name + " (" + streamKV.value.descr + ")"}}
             </button>
@@ -32,8 +32,8 @@
     <div>
       <button mat-button [matMenuTriggerFor]="$any(menuSelectRecording)">Select Recording</button>
       <mat-menu #menuSelectRecording="matMenu">
-        <ng-container *ngFor="let camKV of cameras | keyvalue">
-          <ng-container *ngFor="let streamKV of camKV.value.streams | keyvalue">
+        <ng-container *ngFor="let camKV of cameras | keyvalue: cameraSvc.compareFn">
+          <ng-container *ngFor="let streamKV of camKV.value.streams | keyvalue: cameraSvc.compareFn">
             <button mat-menu-item (click)="showRecording(camKV.value, streamKV.value);menuClosed()" *ngIf="streamKV.value.recording.enabled">
               {{camKV.value.name + " (" + streamKV.value.descr + ")"}}
             </button>
@@ -49,7 +49,7 @@
         <button mat-menu-item [matMenuTriggerFor]="$any(menuCameraAdmin)">Camera Admin</button>
       </mat-menu>
       <mat-menu #menuCameraSettings="matMenu">
-        <ng-container *ngFor="let camKV of cameras | keyvalue">
+        <ng-container *ngFor="let camKV of cameras | keyvalue: cameraSvc.compareFn">
           <button *ngIf="camKV.value.address!=''&&camKV.value.cameraParamSpecs.camType !== cameraTypes.none" mat-menu-item
                   (click)="cameraControl(camKV.value);menuClosed()">
             {{camKV.value.name}}
@@ -57,7 +57,7 @@
         </ng-container>
       </mat-menu>
       <mat-menu #menuCameraAdmin="matMenu">
-        <ng-container *ngFor="let camKV of cameras | keyvalue">
+        <ng-container *ngFor="let camKV of cameras | keyvalue: cameraSvc.compareFn">
           <span matTooltip="Disabled for guest" matTooltipClass="tooltip" [matTooltipDisabled]="!isGuest">
             <button *ngIf="camKV.value.address!=''" mat-menu-item
                     [disabled]="isGuest"

--- a/client/src/app/nav/nav.component.ts
+++ b/client/src/app/nav/nav.component.ts
@@ -40,7 +40,7 @@ export class NavComponent implements OnInit, AfterViewInit, OnDestroy {
   talkOffSubscription!: StompSubscription;
   transportWarningSubscription!: StompSubscription;
 
-  constructor(private cameraSvc: CameraService, public utilsService: UtilsService, private userIdle: UserIdleService, private dialog: MatDialog, private cpService: CloudProxyService) {
+  constructor(public cameraSvc: CameraService, public utilsService: UtilsService, private userIdle: UserIdleService, private dialog: MatDialog, private cpService: CloudProxyService) {
     this.cpService.getStatus().subscribe((status: boolean) => {
         this.utilsService.cloudProxyRunning = status;
       },

--- a/fmp4-ws-media-server/bucket-brigade.go
+++ b/fmp4-ws-media-server/bucket-brigade.go
@@ -26,15 +26,15 @@ type BucketBrigadeFeeder struct {
 	pktFeed          chan Packet
 }
 
-func NewBucketBrigade(used bool) (bucketBrigade BucketBrigade) {
-	const cacheLength int = 200
+func NewBucketBrigade(preambleFrames int) (bucketBrigade BucketBrigade) {
+	cacheLength := preambleFrames + 1
 	bucketBrigade = BucketBrigade{
 		Cache:       make([]Packet, cacheLength),
 		feeders:     make([]*BucketBrigadeFeeder, 0),
 		started:     false,
 		inputIndex:  0,
 		cacheLength: cacheLength,
-		bbUsed:      used,
+		bbUsed:      true,
 		gopCache:    NewGopCache(true)}
 	return
 }

--- a/fmp4-ws-media-server/config.go
+++ b/fmp4-ws-media-server/config.go
@@ -43,6 +43,7 @@ type StreamC struct {
 	NetcamUri           string `json:"netcam_uri"`
 	MediaServerInputUri string `json:"media_server_input_uri"`
 	URI                 string `json:"uri"`
+	PreambleFrames      int    `json:"preambleFrames"`
 }
 
 type CameraParamSpecs struct {

--- a/fmp4-ws-media-server/http.go
+++ b/fmp4-ws-media-server/http.go
@@ -102,7 +102,6 @@ func serveHTTP() {
 			log.Errorf("Cannot add %s, there is already an existing stream with that id", suuid)
 			return
 		}
-
 		log.Infof("Input connected for %s", suuid)
 		readCloser := req.Body
 

--- a/server/grails-app/controllers/server/MotionController.groovy
+++ b/server/grails-app/controllers/server/MotionController.groovy
@@ -49,6 +49,7 @@ class Stream {
     Integer audio_sample_rate = 0
     String media_server_input_uri=''
     Motion motion=new Motion()
+    Integer preambleFrames = 100;
     Integer video_width=0
     Integer video_height=0
     Recording recording=new Recording()


### PR DESCRIPTION
*  Change [attr.disabled] back to [disabled]. The former stopped the "It looks like you're using the disabled attribute with a reactive form directive." warnings, but also stopped it working!
*  Fix bug where the doorbell would come up with the wrong stream selected for motion after onvif discovery.
* Also fixed the same bug in multgicam, view and the nav component
* For the width and height of the scrollable content use width: 100% and height: calc(100dvh - ${boundingRect.top+20}px) to make the dynamic sizing more accurate.
* Display the config table in a scrollable window so the menu bar and page title remain in place while the table is scrolled vertically or horizontally.
* New config parameter (preambleFrames) to set the amount of delay on the feed to the ffmpeg recorder. This gives control over the amount of preamble on recordings.
