### PR TITLE
* Use route guards to prevent guest access to client user only forms …

### DIFF
--- a/client/src/app/app-routing.module.ts
+++ b/client/src/app/app-routing.module.ts
@@ -1,16 +1,17 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
+import {OnlyClientUsersService} from "./guards/only-client-users.service";
 
 const routes: Routes = [
   {path: 'live/:streamName', loadChildren: () => import('./live-container/live-container.module').then(m => m.LiveContainerModule)},
   {path: 'recording/:streamName', loadChildren: () => import('./recording-control/recording-control.module').then(m => m.RecordingControlModule)},
   {path: 'multicam', loadChildren: () => import('./multi-cam-view/multi-cam-view.module').then(m => m.MultiCamViewModule)},
-  {path: 'changeemail', loadChildren: () => import('./change-email/change-email.module').then(m => m.ChangeEmailModule)},
-  {path: 'changepassword', loadChildren: () => import('./change-password/change-password.module').then(m => m.ChangePasswordModule) }  ,
+  {path: 'changeemail', loadChildren: () => import('./change-email/change-email.module').then(m => m.ChangeEmailModule), canActivate: [OnlyClientUsersService]},
+  {path: 'changepassword', loadChildren: () => import('./change-password/change-password.module').then(m => m.ChangePasswordModule), canActivate: [OnlyClientUsersService]},
   {path: 'cameraparams/:camera', loadChildren: () => import('./camera-params/cam-params.module').then(m => m.CamParamsModule)},
   {path: 'configsetup', loadChildren: () => import('./config-setup/config-setup.module').then(m => m.ConfigSetupModule)},
   {path: 'general', loadChildren: () => import('./general/general.module').then(m => m.GeneralModule)},
-  {path: 'wifi', loadChildren: () => import('./wifi-settings/wifi-settings.module').then(m => m.WifiSettingsModule)},
+  {path: 'wifi', loadChildren: () => import('./wifi-settings/wifi-settings.module').then(m => m.WifiSettingsModule), canActivate: [OnlyClientUsersService]},
 ];
 
 @NgModule({

--- a/client/src/app/general/general-routing.module.ts
+++ b/client/src/app/general/general-routing.module.ts
@@ -10,15 +10,16 @@ import {DrawdownCalcContainerComponent} from "../drawdown-calc-container/drawdow
 import {
   CreateUserAccountContainerComponent
 } from "../create-user-account-container/create-user-account-container.component";
+import {OnlyClientUsersService} from "../guards/only-client-users.service";
 
 const routes: Routes = [
-  {path: 'setupguestaccount', component: SetUpGuestAccountComponent},
-  {path: 'setip', component: SetIpComponent},
-  {path: 'cloudproxy', component: CloudProxyComponent},
-  {path: 'cua', component: CreateUserAccountContainerComponent},
-  {path: 'getactiveipaddresses', component: GetActiveIPAddressesComponent},
+  {path: 'setupguestaccount', component: SetUpGuestAccountComponent, canActivate: [OnlyClientUsersService]},
+  {path: 'setip', component: SetIpComponent, canActivate: [OnlyClientUsersService]},
+  {path: 'cloudproxy', component: CloudProxyComponent, canActivate: [OnlyClientUsersService]},
+  {path: 'cua', component: CreateUserAccountContainerComponent, canActivate: [OnlyClientUsersService]},
+  {path: 'getactiveipaddresses', component: GetActiveIPAddressesComponent, canActivate: [OnlyClientUsersService]},
   {path: 'dc', component: DrawdownCalcContainerComponent},
-  {path: 'camadmin/:camera', component: CameraAdminPageHostingComponent},
+  {path: 'camadmin/:camera', component: CameraAdminPageHostingComponent, canActivate: [OnlyClientUsersService]},
   {path: 'about', component: AboutComponent}
 ];
 @NgModule({

--- a/client/src/app/guards/only-client-users.service.ts
+++ b/client/src/app/guards/only-client-users.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import {ActivatedRouteSnapshot, CanActivate, RouterStateSnapshot, UrlTree } from '@angular/router';
+import { Observable } from 'rxjs';
+import {map} from "rxjs/operators";
+import { UtilsService } from '../shared/utils.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class OnlyClientUsersService implements CanActivate {
+
+  constructor(private utilsService: UtilsService) { }
+
+  canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
+    return this.utilsService.getUserAuthorities().pipe(
+      // Map to true if authority is ROLE_CLIENT
+      map((val) =>
+        val.find(v => v.authority === 'ROLE_CLIENT') !== undefined
+      ));
+  }
+}

--- a/client/src/app/shared/utils.service.ts
+++ b/client/src/app/shared/utils.service.ts
@@ -308,4 +308,10 @@ export class UtilsService {
   set cloudProxyRunning(value: boolean) {
     this._cloudProxyRunning = value;
   }
+
+  getUserAuthorities(): Observable<{ authority: string }[]> {
+    return this.http.post<{ authority: string }[]>(this._baseUrl.getLink('utils', 'getUserAuthorities'), '', this.httpJSONOptions).pipe(
+        catchError((err: HttpErrorResponse) => throwError(err))
+    );
+  }
 }

--- a/server/grails-app/controllers/server/UtilsController.groovy
+++ b/server/grails-app/controllers/server/UtilsController.groovy
@@ -212,4 +212,17 @@ class UtilsController {
     protected def audio(@Payload byte[] data) {
         utilsService.audio(data)
     }
+
+    @Secured(['ROLE_CLIENT', 'ROLE_GUEST'])
+    def getUserAuthorities() {
+        ObjectCommandResponse result
+        result = utilsService.getUserAuthorities()
+        if (result.status != PassFail.PASS) {
+            logService.cam.error "getUserAuthorities: error: ${result.error}"
+            render(status: 500, text: result.error)
+        } else {
+            logService.cam.info("getUserAuthorities: success")
+            render result.responseObject as JSON
+        }
+    }
 }

--- a/server/grails-app/services/security/cam/UtilsService.groovy
+++ b/server/grails-app/services/security/cam/UtilsService.groovy
@@ -12,6 +12,7 @@ import org.springframework.core.io.Resource
 import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.scheduling.annotation.EnableScheduling
 import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.security.core.context.SecurityContextHolder
 import security.cam.audiobackchannel.RtspClient
 import security.cam.commands.SMTPData
 import security.cam.commands.SetupSMTPAccountCommand
@@ -452,4 +453,24 @@ class UtilsService {
             }
         }
     }
+
+    ObjectCommandResponse getUserAuthorities() {
+        ObjectCommandResponse result = new ObjectCommandResponse()
+        try {
+            if(SecurityContextHolder.getContext().getAuthentication() == null) {
+                def ex = new Expando()
+                ex.setProperty('authority', 'ROLE_CLIENT')
+                result.responseObject = [ex.properties]  // In development/debug mode
+            }
+            else  // Logged in
+                result.responseObject = SecurityContextHolder.getContext().getAuthentication().getAuthorities()
+        }
+        catch (Exception ex) {
+            logService.cam.error("${ex.getClass().getName()} in getUserAuthorities: ${ex.getCause()} ${ex.getMessage()}")
+            result.status = PassFail.FAIL
+            result.error = ex.getMessage()
+        }
+        return result
+    }
 }
+

--- a/xtrn-scripts-and-config/deb-file-creation/postinst
+++ b/xtrn-scripts-and-config/deb-file-creation/postinst
@@ -72,10 +72,10 @@ find /etc/security-cam -type f -print0 | xargs -0 chmod 664
 
 chgrp -R security-cam /etc/security-cam/
 chown sec-cam:security-cam /var/log/motion
-chown tomcat:security-cam /var/log/security-cam
-chown tomcat:security-cam /var/log/camera-recordings-service
-chown tomcat:security-cam /var/log/fmp4-ws-media-service
-chown tomcat:tomcat /var/log/tomcat9
+chown -R tomcat:security-cam /var/log/security-cam
+chown -R tomcat:security-cam /var/log/camera-recordings-service
+chown -R tomcat:security-cam /var/log/fmp4-ws-media-service
+chown -R tomcat:tomcat /var/log/tomcat9
 # Make the following scripts executable
 chmod +x /etc/security-cam/install-cert.sh
 chmod +x /etc/security-cam/processmotionrecordings.sh || true


### PR DESCRIPTION
…by typing in the #/url. (The restful api functions are protected by their assigned roles).

* Make chown recursive on log locations as certain re-installation scenarios can result in log contents having number only user and groups, preventing access by the application.